### PR TITLE
Use AnyObject for FlatCacheListener Protocol

### DIFF
--- a/FlatCache/FlatCache.swift
+++ b/FlatCache/FlatCache.swift
@@ -38,7 +38,7 @@ private extension Cachable {
     }
 }
 
-public protocol FlatCacheListener: class {
+public protocol FlatCacheListener: AnyObject {
     func flatCacheDidUpdate(cache: FlatCache, update: FlatCache.Update)
 }
 


### PR DESCRIPTION
As of Swift 4, the preferred method for limiting protocol adoption to
classes has changed from [`class` in favor of AnyObject](https://forums.swift.org/t/class-only-protocols-class-vs-anyobject/11507/9)